### PR TITLE
Remove  `.refs`. selector of passed component from Redux - `.wrappedInstance` is now directly available on the passed component in `react-redux` v5.0.1–

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ function connectWithTransitionGroup(connect) {
 
   willFunctions.forEach(function(key) {
     connect.prototype[key] = function(cb) {
-      if (this.refs.wrappedInstance[key]) {
-        this.refs.wrappedInstance[key](cb);
+      if (this.wrappedInstance[key]) {
+        this.wrappedInstance[key](cb);
       } else {
         cb();
       }
@@ -35,8 +35,8 @@ function connectWithTransitionGroup(connect) {
 
   didFunctions.forEach(function(key) {
     connect.prototype[key] = function() {
-      if (this.refs.wrappedInstance[key]) {
-        this.refs.wrappedInstance[key]();
+      if (this.wrappedInstance[key]) {
+        this.wrappedInstance[key]();
       }
     }
   });


### PR DESCRIPTION
The current version of `connect-with-transition-group` (v0.2.0) breaks with `react-redux` v5.0.1, since `.wrappedInstance` no longer is in the `refs` prop but directly available on the passed component. This PR fixes that. 